### PR TITLE
PR_Move_Hard_Coded_Email_Template_To_Settings

### DIFF
--- a/Modules/UpendoDnnSimpleAuthProvider/Components/DnnGlobal.cs
+++ b/Modules/UpendoDnnSimpleAuthProvider/Components/DnnGlobal.cs
@@ -1,0 +1,114 @@
+﻿#region License
+
+/*
+Copyright © Upendo Ventures, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES 
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using DotNetNuke.Common.Utilities;
+using DotNetNuke.Data;
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Framework;
+using DotNetNuke.Services.Localization;
+
+namespace UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.Components
+{
+    public interface IDnnGlobal
+    {
+        int GetPortalId();
+        PortalInfo GetCurrentPortal();
+        PortalSettings GetCurrentPortalSettings();
+        Dictionary<string, Locale> GetLocales();
+        Locale GetLocale(string code);
+        CultureInfo GetPageLocale();
+    }
+
+
+    [Serializable]
+    public class DnnGlobal : ServiceLocator<IDnnGlobal, DnnGlobal>
+    {
+        public static void SetPortalSettings(PortalSettings pSettings)
+        {
+            DnnGlobalImpl.Settings = pSettings;
+        }
+
+        protected override Func<IDnnGlobal> GetFactory()
+        {
+            return () => new DnnGlobalImpl();
+        }
+
+        internal class DnnGlobalImpl : IDnnGlobal
+        {
+            [ThreadStatic] private static PortalSettings _settings;
+
+            internal static PortalSettings Settings
+            {
+                get { return _settings; }
+                set { _settings = value; }
+            }
+
+            public int GetPortalId()
+            {
+                var sett = GetCurrentPortalSettings();
+
+                if (sett != null)
+                    return sett.PortalId;
+                return Null.NullInteger;
+            }
+
+            public PortalInfo GetCurrentPortal()
+            {
+                var controller = new PortalController();
+                return controller.GetPortal(GetPortalId());
+            }
+
+            public PortalSettings GetCurrentPortalSettings()
+            {
+                return Settings ?? PortalSettings.Current;
+            }
+
+            public Dictionary<string, Locale> GetLocales()
+            {
+                return LocaleController.Instance.GetLocales(GetPortalId());
+            }
+
+            public Locale GetLocale(string code)
+            {
+                var locale = LocaleController.Instance.GetLocale(GetPortalId(), code);
+                if (locale == null)
+                {
+                    // workaround to explicitly fill and retrieve the locales under some conditions
+                    // under these (unknown) conditions, the CMS API doesn't aways fill the locale collection
+                    var locales = CBO.FillDictionary("CultureCode", DataProvider.Instance().GetLanguages(), new Dictionary<string, Locale>(StringComparer.OrdinalIgnoreCase));
+                    locales.TryGetValue(code, out locale);
+                }
+                return locale;
+            }
+
+            public CultureInfo GetPageLocale()
+            {
+                var portalSettings = Instance.GetCurrentPortalSettings();
+                return Localization.GetPageLocale(portalSettings);
+            }
+        }
+    }
+}

--- a/Modules/UpendoDnnSimpleAuthProvider/Components/Email.cs
+++ b/Modules/UpendoDnnSimpleAuthProvider/Components/Email.cs
@@ -1,4 +1,6 @@
-﻿/*
+﻿#region License
+
+/*
 Copyright © Upendo Ventures, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
@@ -17,6 +19,8 @@ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#endregion
+
 using DotNetNuke.Data;
 using DotNetNuke.Entities.Controllers;
 using System;
@@ -28,6 +32,9 @@ using System.Web;
 using System.Text;
 using DotNetNuke.Entities.Users;
 using UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.Components;
+using DotNetNuke.Entities.Portals;
+using System.IO;
+using System.Web.Hosting;
 
 namespace UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.Components
 {
@@ -37,89 +44,16 @@ namespace UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.Components
         {
             var randomCode = code;
             string logo = UtilityMethods.GetSiteIconUrl().ToString();
-            bool isSecureConnection = HttpContext.Current.Request.IsSecureConnection;
-            string logoUrl = isSecureConnection ? "https://"+ logo : "http://"+ logo;
             string emailSubject = "Upendo Authenticator Provider confirmation code: " + randomCode;
             var hostEmail = HostController.Instance.GetString("HostEmail");
             var toEmailAddress = userEmail;
-            string fecha = DateTime.Now.ToString();
-            string emailBody = @"
-<!DOCTYPE html>
-<html xmlns:v=""urn:schemas-microsoft-com:vml"">
-<head>
-  <meta http-equiv=""Content-Type"" content=""text/html; charset=unicode"">
-  <title>Upendo Authenticator Provider confirmation code:""; emailBody += randomCode; emailBody += $@""</title>
-  <style>
-    @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;700&display=swap');
-    body {
-      font-family: 'Montserrat', Arial, sans-serif; /* Utiliza la fuente Montserrat */
-    }
-    .header h1 {
-      font-weight: 700; 
-    }
-    .heroparagraph,
-    .contentparagraph {
-      font-weight: 300;
-    }
-    .container {
-      width: 100%;
-      background: white;
-      border-collapse: collapse;
-      border-radius: 8px;
-      box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.1);
-    }
-    .header img {
-      width: 120px;
-      height: 36px;
-      margin: 32px 0;
-    }
-    .code-box {
-      background: #F5F4F5;
-      text-align: center;
-      vertical-align: middle;
-      color: black;
-      font-size: 22.5pt;
-    }
-    .footer {
-      text-align: center;
-      padding: 15px;
-      color: dimgray;
-    }
-  </style>
-</head>
-<body>
-  <table class=""container"">
-    <tr>
-      <td class=""header"" style=""padding: 24pt 0.75pt"">
-        <div align=""center"">
-         <img src="""; emailBody += logoUrl; emailBody += $@""" alt=""logo"">
-        </div>
-      </td>
-    </tr>
-    <tr>
-      <td style=""padding: 0 0.75pt"">
-        <div style=""margin: 0 37.5pt 22.5pt"">
-          <h1>Confirm your email address</h1>
-          <p class=""heroparagraph"">Your confirmation code is below — enter it in your open browser window and we'll help you get signed in.</p>
-        </div>
-        <div class=""code-box"">"; emailBody += randomCode; emailBody += $@"</div>
-        <div style=""margin: 0 37.5pt 22.5pt"">
-          <p class=""contentparagraph"">If you didn’t request this email, there’s nothing to worry about — you can safely ignore it.</p>
-        </div>
-      </td>
-    </tr>
-    <tr>
-      <td style=""padding: 15pt 0.75pt"">
-        <div class=""footer"">
-          ©2023 Upendo Ventures.<br>
-          548 Market St. #65401, San Francisco, CA 94104<br>All rights reserved.
-        </div>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>";
-            
+            string valueSettings = PortalController.GetPortalSetting("UpendoSimpleDnnAuth.ConfirmEmail", DnnGlobal.Instance.GetPortalId(), string.Empty);
+            string serverPath = HostingEnvironment.MapPath(valueSettings);
+            var templateContent = File.ReadAllText(serverPath);
+            string emailBody = templateContent;
+            emailBody = emailBody.Replace("CODE", randomCode);
+            emailBody = emailBody.Replace("LOGO_URL", logo);
+
             DotNetNuke.Services.Mail.Mail.SendEmail(hostEmail, toEmailAddress, emailSubject, emailBody);
         }
 

--- a/Modules/UpendoDnnSimpleAuthProvider/Components/UtilityMethods.cs
+++ b/Modules/UpendoDnnSimpleAuthProvider/Components/UtilityMethods.cs
@@ -33,6 +33,7 @@ using DotNetNuke.UI.Skins.Controls;
 using UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.Data;
 using UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.Data.Cryptography;
 using DotNetNuke.Entities.Portals;
+using System.Web;
 
 namespace UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.Components
 {
@@ -198,9 +199,10 @@ namespace UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.Components
             string portalAlias = portalSettings.PortalAlias.HTTPAlias;
             string portalHomeDirectory = portalSettings.HomeDirectory;
             string completeLogoUrl = $"{portalAlias}{portalHomeDirectory}{logoFile}";
-
+            bool isSecureConnection = HttpContext.Current.Request.IsSecureConnection;
+            string logoUrl = isSecureConnection ? "https://" + completeLogoUrl : "http://" + completeLogoUrl;
             // Return the complete logo URL
-            return completeLogoUrl;
+            return logoUrl;
         }
     }
 }

--- a/Modules/UpendoDnnSimpleAuthProvider/Providers/DataProviders/SqlDataProvider/01.00.00.SqlDataProvider
+++ b/Modules/UpendoDnnSimpleAuthProvider/Providers/DataProviders/SqlDataProvider/01.00.00.SqlDataProvider
@@ -30,6 +30,19 @@ GO
 CREATE NONCLUSTERED INDEX [IX_{objectQualifier}Upendo_SimpleAuthVerification_Id] ON {databaseOwner}[{objectQualifier}Upendo_SimpleAuthVerification] ([Id]);
 GO
 
+INSERT INTO {databaseOwner}[{objectQualifier}PortalSettings]
+        ( PortalID ,
+          SettingName ,
+          SettingValue ,
+          CreatedByUserID ,
+          CreatedOnDate ,
+          LastModifiedByUserID ,
+          LastModifiedOnDate ,
+          CultureCode
+        )
+		SELECT PortalID, 'UpendoSimpleDnnAuth.ConfirmEmail', '/DesktopModules/UpendoDnnSimpleAuthProvider/Templates/EmailTemplate.html', -1, GETDATE(), -1, GETDATE(), '' FROM {databaseOwner}[{objectQualifier}Portals]
+GO
+
 /*
 
 END OF FILE

--- a/Modules/UpendoDnnSimpleAuthProvider/Providers/DataProviders/SqlDataProvider/Uninstall.SqlDataProvider
+++ b/Modules/UpendoDnnSimpleAuthProvider/Providers/DataProviders/SqlDataProvider/Uninstall.SqlDataProvider
@@ -10,6 +10,8 @@ IF NOT OBJECT_ID('{databaseOwner}[{objectQualifier}Upendo_SimpleAuthVerification
     DROP TABLE {databaseOwner}[{objectQualifier}Upendo_SimpleAuthVerification];
 GO
 
+DELETE FROM {databaseOwner}[{objectQualifier}PortalSettings] WHERE SettingName = 'UpendoSimpleDnnAuth.ConfirmEmail';
+GO
 /*
 
 END OF FILE

--- a/Modules/UpendoDnnSimpleAuthProvider/Templates/EmailTemplate.html
+++ b/Modules/UpendoDnnSimpleAuthProvider/Templates/EmailTemplate.html
@@ -1,0 +1,82 @@
+﻿<!DOCTYPE html>
+<html xmlns:v="urn:schemas-microsoft-com:vml">
+<head>
+    <meta http-equiv="Content-Type" content="text /html; charset=unicode">
+    <title>Upendo Authenticator Provider confirmation code: CODE</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;700&display=swap');
+
+        body {
+            font-family: 'Montserrat', Arial, sans-serif; /* Utiliza la fuente Montserrat */
+        }
+
+        .header h1 {
+            font-weight: 700;
+        }
+
+        .heroparagraph,
+        .contentparagraph {
+            font-weight: 300;
+        }
+
+        .container {
+            width: 100%;
+            background: white;
+            border-collapse: collapse;
+            border-radius: 8px;
+            box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.1);
+        }
+
+        .header img {
+            width: 120px;
+            height: 36px;
+            margin: 32px 0;
+        }
+
+        .code-box {
+            background: #F5F4F5;
+            text-align: center;
+            vertical-align: middle;
+            color: black;
+            font-size: 22.5pt;
+        }
+
+        .footer {
+            text-align: center;
+            padding: 15px;
+            color: dimgray;
+        }
+    </style>
+</head>
+<body>
+    <table class="container">
+        <tr>
+            <td class="header" style="padding: 24pt 0.75pt">
+                <div align="center">
+                    <img src="LOGO_URL" alt="logo">
+                </div>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 0 0.75pt">
+                <div style="margin: 0 37.5pt 22.5pt">
+                    <h1>Confirm your email address</h1>
+                    <p class="heroparagraph">Your confirmation code is below — enter it in your open browser window and we'll help you get signed in.</p>
+                </div>
+                <div class="code-box">CODE</div>
+                <div style="margin: 0 37.5pt 22.5pt">
+                    <p class="contentparagraph">If you didn’t request this email, there’s nothing to worry about — you can safely ignore it.</p>
+                </div>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 15pt 0.75pt">
+                <div class="footer">
+                    ©2023 Upendo Ventures.<br>
+                    548 Market St. #65401, San Francisco, CA 94104<br>All rights reserved.
+                </div>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/Modules/UpendoDnnSimpleAuthProvider/UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.csproj
+++ b/Modules/UpendoDnnSimpleAuthProvider/UpendoVentures.Auth.UpendoDnnSimpleAuthProvider.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <Compile Include="Components\AuthConfigBase.cs" />
     <Compile Include="Components\Const.cs" />
+    <Compile Include="Components\DnnGlobal.cs" />
     <Compile Include="Components\Email.cs" />
     <Compile Include="Components\Json.cs" />
     <Compile Include="Components\RandomCodeGenerator.cs" />
@@ -167,7 +168,9 @@
     <Content Include="Logoff.ascx" />
     <Content Include="Settings.ascx" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Templates\" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>


### PR DESCRIPTION
## Related to Issue
Fixes #27 

## Description
In this PR several functionalities were added with which the expected objective was achieved to solve what was referred to in Issue #27.

## Change Made
- Create DnnGlobal.cs.
I have reused this file that was present in the Hotcackes solution to access all the PortalSettings functions comfortably.

- Update Email.cs.
Removed the static HTML content from the email body to get it from the new template file using PortalSettings to get the location of the file that currently contains the email body content.

- Update UtilityMethods.cs.
Functions that were previously in the Email.cs file to verify secure connections have been moved to the GetSiteIconUrl() method.

- Update SqlDataProvider and Uninstall.SqlDataProvider.
New Scritps have been added to the SqlDataProvider and Uninstall.SqlDataProvider files to add a new value to the PortalSettings Table and to remove it when the module is uninstalled.

- Add EmailTemplate.html.
Added this new HTML type file and moved the email body content to this file.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
